### PR TITLE
feat: add gpt-oss models

### DIFF
--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -61,6 +61,9 @@ export const PROVIDER_TOOL_SUPPORT: Record<string, (model: string) => boolean> =
       ) {
         return true;
       }
+      if (model.toLowerCase().includes("gpt-oss")) {
+        return true;
+      }
       // https://ai.google.dev/gemma/docs/capabilities/function-calling
       if (model.toLowerCase().startsWith("gemma")) {
         return true;
@@ -237,6 +240,7 @@ export const PROVIDER_TOOL_SUPPORT: Record<string, (model: string) => boolean> =
         "openai/o1",
         "openai/o3",
         "openai/o4",
+        "openai/gpt-oss",
         "anthropic/claude-3",
         "anthropic/claude-4",
         "microsoft/phi-3",

--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -177,6 +177,7 @@ export const PROVIDER_TOOL_SUPPORT: Record<string, (model: string) => boolean> =
           "firefunction-v2",
           "mistral",
           "devstral",
+          "gpt-oss",
         ].some((part) => modelName.toLowerCase().includes(part))
       ) {
         return true;

--- a/gui/src/pages/AddNewModel/configs/models.ts
+++ b/gui/src/pages/AddNewModel/configs/models.ts
@@ -87,6 +87,34 @@ export const models: { [key: string]: ModelPackage } = {
     providerOptions: ["novita", "nebius"],
     isOpenSource: true,
   },
+  gptOss20B: {
+    title: "gpt-oss-20b",
+    description:
+      "OpenAI's 20B open-weight model with native tool use and reasoning for agentic tasks.",
+    refUrl: "https://huggingface.co/openai/gpt-oss-20b",
+    params: {
+      title: "gpt-oss-20b",
+      model: "openai/gpt-oss-20b",
+      contextLength: 128_000,
+    },
+    icon: "openai.png",
+    providerOptions: ["vllm"],
+    isOpenSource: true,
+  },
+  gptOss120B: {
+    title: "gpt-oss-120b",
+    description:
+      "OpenAI's 120B flagship open-weight model built for complex, high‑reasoning agentic workflows.",
+    refUrl: "https://huggingface.co/openai/gpt-oss-120b",
+    params: {
+      title: "gpt-oss-120b",
+      model: "openai/gpt-oss-120b",
+      contextLength: 128_000,
+    },
+    icon: "openai.png",
+    providerOptions: ["vllm"],
+    isOpenSource: true,
+  },
   llama318BChat: {
     title: "Llama 3.1 8B",
     description: "A model from Meta, fine-tuned for chat",


### PR DESCRIPTION
## Summary
- expose gpt-oss-20b and gpt-oss-120b in the Add New Model catalog for vLLM
- recognize gpt-oss models in tool support for openai and openrouter providers

## Testing
- `npm test` (packages/llm-info)
- `npm run build` (packages/llm-info)
- `npm test` (core) *(fails: Cannot find module '@continuedev/fetch')*
- `npm run tsc:check` (core) *(fails: Cannot find module '@continuedev/fetch' and others)*
- `npm test` (gui) *(fails: Failed to resolve entry for package '@continuedev/config-yaml')*
- `npm run tsc:check` (gui) *(fails: Cannot find module '@continuedev/config-yaml' and others)*

------
https://chatgpt.com/codex/tasks/task_e_6892ab60b12c8333bba42b60705d91c4